### PR TITLE
feat: add get methods

### DIFF
--- a/app/controllers/chores_controller.rb
+++ b/app/controllers/chores_controller.rb
@@ -1,4 +1,10 @@
 class ChoresController < ApplicationController
+  def show
+    id = params[:id]
+    chore = Chore.find_by(id: id)
+    return render status: 200, json: chore.as_json
+  end
+
   def create
     begin
       params.require(%i[name description hideout_id status])

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,4 +1,10 @@
 class ExpensesController < ApplicationController
+  def show
+    id = params[:id]
+    expense = Expense.find_by(id: id)
+    return render status: 200, json: expense.as_json
+  end
+
   def create
     begin
       params.require(%i[name amount hideout_id active])

--- a/app/controllers/hideouts_controller.rb
+++ b/app/controllers/hideouts_controller.rb
@@ -1,7 +1,31 @@
 require_relative '../helpers/hideout_helper.rb'
 
-class HideoutController < ApplicationController
+class HideoutsController < ApplicationController
   @@hideout_colors = %w[red blue purple yellow green orange]
+
+  def show
+    id = params[:id]
+    hideout = Hideout.find_by(id: id)
+    return render status: 200, json: hideout.as_json
+  end
+
+  def users
+    id = params[:id]
+    users = User.where(hideout_id: id)
+    return render status: 200, json: users.to_json
+  end
+
+  def chores
+    id = params[:id]
+    chores = Chore.where(hideout_id: id)
+    return render status: 200, json: chores.to_json
+  end
+
+  def expenses
+    id = params[:id]
+    expenses = Expense.where(hideout_id: id)
+    return render status: 200, json: expenses.to_json
+  end
 
   def create
     begin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,12 @@ class UsersController < ApplicationController
   @@firebase_signup_URI = URI("https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=#{ENV['FIREBASE_API_KEY']}")
   @@hideout_colors = %w[red blue purple yellow green orange]
 
+  def show
+    id = params[:id]
+    user = User.find_by(id: id)
+    return render status: 200, json: user.as_json
+  end
+
   def create
     begin
       params.require(%i[first_name last_name email password])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,12 @@ Rails.application.routes.draw do
   delete '/api/users/:id/hideouts', to: 'users#leave'
 
   get '/api/hideouts/:id', to: 'hideouts#show'
-  post '/api/hideouts', to: 'hideout#create'
-  put '/api/hideouts/:id', to: 'hideout#update'
-  delete '/api/hideouts/:id', to: 'hideout#destroy'
+  get '/api/hideouts/:id/users', to: 'hideouts#users'
+  get '/api/hideouts/:id/chores', to: 'hideouts#chores'
+  get '/api/hideouts/:id/expenses', to: 'hideouts#expenses'
+  post '/api/hideouts', to: 'hideouts#create'
+  put '/api/hideouts/:id', to: 'hideouts#update'
+  delete '/api/hideouts/:id', to: 'hideouts#destroy'
 
   get '/api/chores/:id', to: 'chores#show'
   post '/api/chores', to: 'chores#create'

--- a/lib/middleware/verify_user_permissions.rb
+++ b/lib/middleware/verify_user_permissions.rb
@@ -14,9 +14,8 @@ module Middleware
           User.find_by!(id: path_id)
           return 400, {}, [] if path_id != payload['id']
         elsif request.method != 'POST' and request.path.include?('/api/hideouts')
-          return 400, {}, [] if path_id != payload['hideout_id']
           hideout = Hideout.find_by!(id: path_id)
-          return 401, {}, [] if hideout.owner_id != payload['id']
+          return 401, {}, [] if hideout.id != payload['hideout_id']
         elsif request.method != 'POST' and request.path.include?('/api/chores')
           chore = Chore.find_by!(id: path_id)
           return 401, {}, [] if chore.hideout_id != payload['hideout_id']


### PR DESCRIPTION
- HID-71

With this PR, the following new routes are available for use:

1. GET /api/hideouts/:id
2. GET /api/chores/:id
3. GET /api/expenses/:id
4. GET /api/users/:id
5. GET /api/hideouts/:id/users
6. GET /api/hideouts/:id/chores
7. GET /api/hideouts/:id/expenses

Note that I did not add a GET /api/sessions since I think we should be able to verify whether a user is logged in via cookie / refresh token validation on the frontend. If not, we can always add it later.